### PR TITLE
Related to psalm plugin bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 php:
+    - 7.0
+    - 7.1
+    - 7.2
     - 7.3
+    - 7.4snapshot
 before_install:
     - phpenv config-rm xdebug.ini || true
 install:

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
         "check": [
             "@cs-check",
             "@static-analysis",
-	    "@test"
+            "@test"
         ],
         "cs-check": "phpcs --colors",
         "static-analysis": "psalm",
-	"test": "codecept run -v"
+        "test": "codecept run -v"
     }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -18,7 +18,7 @@ use RuntimeException;
 class Module extends BaseModule
 {
     /** @var array<string,string */
-    private const VERSION_OPERATORS = [
+    private static $VERSION_OPERATORS = [
         'newer than' => '>',
         'older than' => '<',
     ];
@@ -174,11 +174,11 @@ class Module extends BaseModule
      */
     public function havePsalmOfACertainVersionRangeBecauseOf(string $operator, string $version, string $reason): void
     {
-        if (!isset(self::VERSION_OPERATORS[$operator])) {
+        if (!isset(self::$VERSION_OPERATORS[$operator])) {
             throw new TestRuntimeException("Unknown operator: $operator");
         }
 
-        $op = (string) self::VERSION_OPERATORS[$operator];
+        $op = (string) self::$VERSION_OPERATORS[$operator];
 
         if (!$this->seePsalmVersionIs($op, $version)) {
             throw new Skip("This scenario requires Psalm $op $version because of $reason");

--- a/src/Module.php
+++ b/src/Module.php
@@ -18,7 +18,7 @@ use RuntimeException;
 class Module extends BaseModule
 {
     /** @var array<string,string */
-    private static $VERSION_OPERATORS = [
+    const VERSION_OPERATORS = [
         'newer than' => '>',
         'older than' => '<',
     ];
@@ -199,11 +199,11 @@ class Module extends BaseModule
      */
     public function havePsalmOfACertainVersionRangeBecauseOf(string $operator, string $version, string $reason)
     {
-        if (!isset(self::$VERSION_OPERATORS[$operator])) {
+        if (!isset(self::VERSION_OPERATORS[$operator])) {
             throw new TestRuntimeException("Unknown operator: $operator");
         }
 
-        $op = (string) self::$VERSION_OPERATORS[$operator];
+        $op = (string) self::VERSION_OPERATORS[$operator];
 
         if (!$this->seePsalmVersionIs($op, $version)) {
             throw new Skip("This scenario requires Psalm $op $version because of $reason");

--- a/src/Module.php
+++ b/src/Module.php
@@ -45,7 +45,10 @@ class Module extends BaseModule
     /** @var array{type:string,message:string}[] */
     public $errors = [];
 
-    public function _beforeSuite($configuration = []): void
+    /**
+     * @return void
+     */
+    public function _beforeSuite($configuration = [])
     {
         $defaultDir = dirname($this->config['default_file']);
         if (file_exists($defaultDir)) {
@@ -59,12 +62,19 @@ class Module extends BaseModule
             throw new TestRuntimeException('Failed to create dir: ' . $defaultDir);
         }
     }
-    public function _before(TestInterface $test): void
+
+    /**
+     * @return void
+     */
+    public function _before(TestInterface $test)
     {
         $this->errors = [];
     }
 
-    public function runPsalmOn(string $filename): void
+    /**
+     * @return void
+     */
+    public function runPsalmOn(string $filename)
     {
         $this->cli()->runShellCommand(
             $this->config['psalm_path']
@@ -90,7 +100,10 @@ class Module extends BaseModule
         $this->debug($this->remainingErrors());
     }
 
-    public function seeThisError(string $type, string $message): void
+    /**
+     * @return void
+     */
+    public function seeThisError(string $type, string $message)
     {
         if (empty($this->errors)) {
             Assert::fail("No errors");
@@ -109,8 +122,10 @@ class Module extends BaseModule
     /**
      * @Then I see no errors
      * @Then I see no other errors
+     *
+     * @return void
      */
-    public function seeNoErrors(): void
+    public function seeNoErrors()
     {
         if (!empty($this->errors)) {
             Assert::fail("There were errors: \n" . $this->remainingErrors());
@@ -136,24 +151,30 @@ class Module extends BaseModule
 
     /**
      * @Given I have the following code preamble :code
+     *
+     * @return void
      */
-    public function haveTheFollowingCodePreamble(string $code): void
+    public function haveTheFollowingCodePreamble(string $code)
     {
         $this->preamble = $code;
     }
 
     /**
      * @When /I run (?:P|p)salm/
+     *
+     * @return void
      */
-    public function runPsalm(): void
+    public function runPsalm()
     {
         $this->runPsalmOn($this->config['default_file']);
     }
 
     /**
      * @Given I have the following code :code
+     *
+     * @return void
      */
-    public function haveTheFollowingCode(string $code): void
+    public function haveTheFollowingCode(string $code)
     {
         $this->fs()->writeToFile(
             $this->config['default_file'],
@@ -163,16 +184,20 @@ class Module extends BaseModule
 
     /**
      * @Given I have some future Psalm that supports this feature :ref
+     *
+     * @return void
      */
-    public function haveSomeFuturePsalmThatSupportsThisFeature(string $ref): void
+    public function haveSomeFuturePsalmThatSupportsThisFeature(string $ref)
     {
         throw new Skip("Future functionality that Psalm has yet to support: $ref");
     }
 
     /**
      * @Given /I have Psalm (newer than|older than) "([0-9.]+)" \(because of "([^"]+)"\)/
+     *
+     * @return void
      */
-    public function havePsalmOfACertainVersionRangeBecauseOf(string $operator, string $version, string $reason): void
+    public function havePsalmOfACertainVersionRangeBecauseOf(string $operator, string $version, string $reason)
     {
         if (!isset(self::$VERSION_OPERATORS[$operator])) {
             throw new TestRuntimeException("Unknown operator: $operator");
@@ -187,8 +212,10 @@ class Module extends BaseModule
 
     /**
      * @Then I see these errors
+     *
+     * @return void
      */
-    public function seeTheseErrors(TableNode $list): void
+    public function seeTheseErrors(TableNode $list)
     {
         /** @psalm-suppress MixedAssignment */
         foreach (array_values($list->getRows()) as $i => $error) {


### PR DESCRIPTION
if psalm/phpunit-psalm-plugin is intended to support 7.0, travis needs to run checks on 7.0, currently [builds are failing due to syntax in this package](https://travis-ci.org/SignpostMarv/phpunit-psalm-plugin/jobs/492912066) :s 