### PR TITLE
Allow regexps to specify message expectations

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -156,13 +156,25 @@ class Module extends BaseModule
         }
 
         foreach ($this->errors as $i => $error) {
-            if ($error['type'] === $type && preg_match($this->convertToRegexp($message), $error['message'])) {
+            if ($error['type'] === $type && $this->messageMatches($message, $error['message'])) {
                 unset($this->errors[$i]);
                 return;
             }
         }
 
         Assert::fail("Didn't see [ $type $message ] in: \n" . $this->remainingErrors());
+    }
+
+    private function messageMatches(string $expected, string $actual): bool
+    {
+        $regexpDelimiter = '/';
+        if ($expected[0] === $regexpDelimiter && $expected[strlen($expected) - 1] === $regexpDelimiter) {
+            $regexp = $expected;
+        } else {
+            $regexp = $this->convertToRegexp($expected);
+        }
+
+        return (bool) preg_match($regexp, $actual);
     }
 
     /**

--- a/tests/acceptance/PsalmModule.feature
+++ b/tests/acceptance/PsalmModule.feature
@@ -150,6 +150,40 @@ Feature: Psalm module
     When I run Psalm on "C.php"
     Then I see no errors
 
+  Scenario: Using regexps to match error messages
+    Given I have the following code
+      """
+      class C extends PPP {}
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type           | Message               |
+      | UndefinedClass | /P{3} does not exist/ |
+    And I see no other errors
+
+  Scenario: Escaping pipes in regexps
+    Given I have the following code
+      """
+      class C extends PPP {}
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type           | Message                    |
+      | UndefinedClass | /(P\|A){3} does not exist/ |
+    And I see no other errors
+
+  Scenario: Using backslashes in regexps
+    Given I have the following code
+      """
+      class C extends PPP {}
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type           | Message                   |
+      | UndefinedClass | /\bP{3}\b does not exist/ |
+    And I see no other errors
+
+
   Scenario: Psalm crashes
     Given I have the following code in "autoload.php"
       """


### PR DESCRIPTION
Adds support for using raw regexps as expected messages. Regexps are specified using slash delimiters:
```cucumber
Then I see those errors
    | Type           | Message               |
    | UndefinedClass | /P{3} does not exist/ |
``` 