### PR TITLE
feature: allow comparing exit codes

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -63,6 +63,8 @@ class Module extends BaseModule
     /** @var bool */
     private $hasAutoload = false;
 
+    /** @var int */
+    private $exitCode = 0;
 
     public function _beforeSuite($configuration = []): void
     {
@@ -110,6 +112,8 @@ class Module extends BaseModule
         /** @psalm-suppress MissingPropertyType shouldn't be required, but older Psalm needs it */
         $exitCode = (int)$this->cli()->result;
 
+        $this->exitCode = $exitCode;
+
         $this->debug(sprintf('Psalm exit code: %d', $exitCode));
         // $this->debug('Psalm output: ' . $output);
 
@@ -147,6 +151,18 @@ class Module extends BaseModule
 
         $this->runPsalmOn('', $options);
         $this->fs()->amInPath($pwd);
+    }
+
+    /**
+     * @Then I see exit code :code
+     */
+    public function seeExitCode(int $exitCode): void
+    {
+        if ($this->exitCode === $exitCode) {
+            return;
+        }
+
+        Assert::fail("Expected exit code {$exitCode}, got {$this->exitCode}");
     }
 
     public function seeThisError(string $type, string $message): void

--- a/tests/acceptance/PsalmModule.feature
+++ b/tests/acceptance/PsalmModule.feature
@@ -17,6 +17,7 @@ Feature: Psalm module
       """
     When I run Psalm
     Then I see no errors
+    And I see exit code 0
 
   Scenario: Running with errors
     Given I have the following code
@@ -28,6 +29,7 @@ Feature: Psalm module
       | Type                  | Message                                            |
       | InvalidScalarArgument | Argument 1 of atan expects float, string% provided |
     And I see no other errors
+    And I see exit code 1
 
   Scenario: Skipping depending on a certain Psalm version
     Given I have Psalm newer than "999.99" (because of "me wanting to see if it skips")


### PR DESCRIPTION
took a stab at #9 

I figured I wouldn't  make exit code a dependency on comparing errors