### PR TITLE
refactor: extract parsing of output from running psalm

### DIFF
--- a/tests/acceptance/PsalmModule.feature
+++ b/tests/acceptance/PsalmModule.feature
@@ -185,9 +185,27 @@ Feature: Psalm module
       | UndefinedClass | /\bP{3}\b does not exist/ |
     And I see no other errors
 
+  Scenario: Psalm crashes (3.7.x)
+    Given I have Psalm older than "3.8.0" (because of "exit code changed in 3.8.0")
+    And I have the following code in "autoload.php"
+      """
+      <?php missing_function();
+      """
+    And I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true" autoloader="autoload.php">
+        <projectFiles>
+          <directory name="."/>
+        </projectFiles>
+      </psalm>
+      """
+    When I run Psalm
+    Then I see exit code 255
 
-  Scenario: Psalm crashes
-    Given I have the following code in "autoload.php"
+  Scenario: Psalm crashes (3.8.0+)
+    Given I have Psalm newer than "3.7.2" (because of "exit code changed in 3.8.0")
+    And I have the following code in "autoload.php"
       """
       <?php missing_function();
       """

--- a/tests/acceptance/PsalmModule.feature
+++ b/tests/acceptance/PsalmModule.feature
@@ -201,4 +201,4 @@ Feature: Psalm module
       </psalm>
       """
     When I run Psalm
-    Then test fails, but I how do I even test that?
+    Then I see exit code 1


### PR DESCRIPTION
👋 This should purely be a refactor -- I wanted to parse the output from psalm independently from running psalm. I think this would only be a breaking change if someone was only running psalm and not checking for any errors, but simply relying on the exit code to be 0...

-----

I wanted to do this to be able to test a scenario where i made psalm crash. Without this refactor, it's impossible to expect psalm to crash, as the json_decode fails. Granted, it's probably very much an edge case to be testing that psalm crashes...

-----
If you don't want to merge this, perhaps we could change the class fields from `private` --> `protected` so I can override in my codebase?

Thoughts?

https://github.com/psalm/psalm-plugin-laravel/pull/56