### PR TITLE
fix: reset preamble between tests

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -93,6 +93,7 @@ class Module extends BaseModule
         $this->config['psalm_path'] = realpath($this->config['psalm_path']);
         $this->psalmConfig = '';
         $this->fs()->cleanDir($this->config['default_dir']);
+        $this->preamble = '';
     }
 
     /**


### PR DESCRIPTION
This is pretty difficult to write a unit test for, but very simple to decipher so I elected not  to write any tests.

If test case A wants a preamble, and test case B does not, we don't want the preamble from A remaining.