### PR TITLE
Link `composer.lock` to working directory

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -19,6 +19,8 @@ use Behat\Gherkin\Node\TableNode;
 use OutOfBoundsException;
 use PHPUnit\Framework\SkippedTestError;
 use RuntimeException;
+use function file_exists;
+use function link;
 
 class Module extends BaseModule
 {
@@ -34,6 +36,8 @@ class Module extends BaseModule
         . "    <directory name=\".\"/>\n"
         . "  </projectFiles>\n"
         . "</psalm>\n";
+
+    private const UPSTREAM_COMPOSER_LOCK_PATH = __DIR__ . '/../../../../composer.lock';
 
     /**
      * @var ?Cli
@@ -96,6 +100,12 @@ class Module extends BaseModule
         $this->config['psalm_path'] = realpath($this->config['psalm_path']);
         $this->psalmConfig = '';
         $this->fs()->cleanDir($this->config['default_dir']);
+
+        if (file_exists(self::UPSTREAM_COMPOSER_LOCK_PATH)) {
+            $this->debug('Linking composer.lock to working directory.');
+            link(self::UPSTREAM_COMPOSER_LOCK_PATH, $this->config['default_dir'] . '/composer.lock');
+        }
+
         $this->preamble = '';
     }
 


### PR DESCRIPTION
When running psalm through this codeception module, the working directory changes. In the working directory psalm is operating on, the projects `composer.lock` is unavailable and thus, psalm won't cache due to the fact that the `composer.lock` is missing.
When linking the projects `composer.lock` to the working directory, psalm starts using its cache which have a positive impact on build times in combination with this module.

---

This implementation only checks for the default location of the `composer.lock` and thus does not handle custom-locations, vendor directories, e.g.

I would love to have this available here as it actually reduces the build time of my psalm plugin:

### Before
```
Time: 01:03.695, Memory: 12.00 MB

OK (31 tests, 0 assertions)
```

### After

```
Time: 00:41.517, Memory: 12.00 MB

OK (31 tests, 0 assertions)
```

**NOTE: The `After` case was the initial run.**

---

I did not debugged this further but sometimes, tests take the same time even if the source code should be cached. I've thought that was due to the fact that the working directory is always wiped but since psalm has a strict file content comparison (so it does not only depend on modified time), I don't know whats going on. I don't have time to dive deeper into codeception - maybe file names sometimes differ or stuff like that.

If this implementation does not fulfill the quality standards you want to have in this module, please let me know on how to optimize this PR so we can create a release 👍🏼 