### PR TITLE
Fix Psalm 4.21 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",
-        "vimeo/psalm": "^3.7.0 || ^4.0.0 || dev-master",
+        "vimeo/psalm": "^3.9.0 || ^4.0.0 || dev-master",
         "phpunit/phpunit": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0"
     },
     "scripts": {

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config ./vendor/vimeo/psalm/config.xsd"

--- a/src/Module.php
+++ b/src/Module.php
@@ -29,7 +29,7 @@ class Module extends BaseModule
     ];
 
     private const DEFAULT_PSALM_CONFIG = "<?xml version=\"1.0\"?>\n"
-        . "<psalm totallyTyped=\"true\" %s>\n"
+        . "<psalm errorLevel=\"1\" %s>\n"
         . "  <projectFiles>\n"
         . "    <directory name=\".\"/>\n"
         . "  </projectFiles>\n"

--- a/tests/acceptance/PsalmModule.feature
+++ b/tests/acceptance/PsalmModule.feature
@@ -87,7 +87,7 @@ Feature: Psalm module
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
         </projectFiles>


### PR DESCRIPTION
`totallyTyped` was deprecated in [Psalm v4.21.0](https://github.com/vimeo/psalm/releases/tag/4.21.0). From the [docs](https://psalm.dev/docs/running_psalm/configuration/#totallytyped): `totallyTyped="true"` is equivalent to `errorLevel="1"`.