### PR TITLE
Feature: Introduce initial support for codeception v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         continue-on-error: ${{matrix.php == '8.0'}}
         strategy:
             matrix:
-                php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php: ['7.4', '8.0', '8.1']
                 deps: ['high', 'low', 'stable']
             fail-fast: false
         steps:

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,18 @@
         }
     },
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "codeception/codeception": "^4.0.3",
+        "codeception/codeception": "^4.1.31 || ^5.0",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "codeception/module-cli": "^1.0.0",
-        "codeception/module-filesystem": "^1.0.2"
+        "codeception/module-filesystem": "^2.0 || ^3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",
         "vimeo/psalm": "^3.7.0 || ^4.0.0 || dev-master",
-        "phpunit/phpunit": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0"
+        "phpunit/phpunit": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0",
+        "codeception/codeception": "^4.1.31 || ^5.0.0-rc3"
     },
     "scripts": {
         "check": [

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "codeception/codeception": "^4.1.31 || ^5.0",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "codeception/module-cli": "^1.0.0",
-        "codeception/module-filesystem": "^2.0 || ^3.0"
+        "codeception/module-filesystem": "^1.0.2 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",
         "vimeo/psalm": "^3.7.0 || ^4.0.0 || dev-master",
-        "phpunit/phpunit": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0",
+        "phpunit/phpunit": "^9.5.20",
         "codeception/codeception": "^4.1.31 || ^5.0.0-rc3"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",
-        "vimeo/psalm": "^3.7.0 || ^4.0.0 || dev-master",
+        "vimeo/psalm": "^4.17.0 || dev-master",
         "phpunit/phpunit": "^9.5.20",
         "codeception/codeception": "^4.1.31 || ^5.0.0-rc3"
     },
@@ -40,6 +40,9 @@
         "test": "codecept run -v"
     },
     "config": {
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
     }
 }

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config ./vendor/vimeo/psalm/config.xsd"

--- a/src/Module.php
+++ b/src/Module.php
@@ -29,7 +29,7 @@ class Module extends BaseModule
     ];
 
     private const DEFAULT_PSALM_CONFIG = "<?xml version=\"1.0\"?>\n"
-        . "<psalm totallyTyped=\"true\" %s>\n"
+        . "<psalm errorLevel=\"1\" %s>\n"
         . "  <projectFiles>\n"
         . "    <directory name=\".\"/>\n"
         . "  </projectFiles>\n"

--- a/tests/acceptance/PsalmModule.feature
+++ b/tests/acceptance/PsalmModule.feature
@@ -204,27 +204,8 @@ Feature: Psalm module
       | UndefinedClass | /\bP{3}\b does not exist/ |
     And I see no other errors
 
-  Scenario: Psalm crashes (3.7.x)
-    Given I have Psalm older than "3.8.0" (because of "exit code changed in 3.8.0")
-    And I have the following code in "autoload.php"
-      """
-      <?php missing_function();
-      """
-    And I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1" autoloader="autoload.php">
-        <projectFiles>
-          <directory name="."/>
-        </projectFiles>
-      </psalm>
-      """
-    When I run Psalm
-    Then I see exit code 255
-
-  Scenario: Psalm crashes (3.8.0+)
-    Given I have Psalm newer than "3.7.2" (because of "exit code changed in 3.8.0")
-    And I have the following code in "autoload.php"
+  Scenario: Psalm crashes
+    Given I have the following code in "autoload.php"
       """
       <?php missing_function_2();
       """

--- a/tests/acceptance/PsalmModule.feature
+++ b/tests/acceptance/PsalmModule.feature
@@ -87,7 +87,7 @@ Feature: Psalm module
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
         </projectFiles>
@@ -213,7 +213,7 @@ Feature: Psalm module
     And I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true" autoloader="autoload.php">
+      <psalm errorLevel="1" autoloader="autoload.php">
         <projectFiles>
           <directory name="."/>
         </projectFiles>
@@ -231,7 +231,7 @@ Feature: Psalm module
     And I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true" autoloader="autoload.php">
+      <psalm errorLevel="1" autoloader="autoload.php">
         <projectFiles>
           <directory name="."/>
         </projectFiles>


### PR DESCRIPTION
Codeception released RC3 a while ago and thus, I'd like to introduce support for it.
Any review would be helpful.

Thanks in advance.

## TL;DR:
- This adds support for `codeception/codeception` v4 & v6
- This adds support for `codeception/module-filesystem` v1, v2 & v3 (not sure if v2 works tho, maybe just adding v1 || v3 might be fine)
- This removes support for ancient PHPUnit versions
- This drops support for PHP <7.4